### PR TITLE
Add way to craft glider wings into opposite form

### DIFF
--- a/src/main/resources/data/kibe/recipes/glider_left_wing_from_right.json
+++ b/src/main/resources/data/kibe/recipes/glider_left_wing_from_right.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "kibe:glider_right_wing"
+    }
+  ],
+  "result": {
+    "item": "kibe:glider_left_wing",
+    "count": 1
+  }
+}

--- a/src/main/resources/data/kibe/recipes/glider_right_wing_from_left.json
+++ b/src/main/resources/data/kibe/recipes/glider_right_wing_from_left.json
@@ -1,0 +1,12 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {
+      "item": "kibe:glider_left_wing"
+    }
+  ],
+  "result": {
+    "item": "kibe:glider_right_wing",
+    "count": 1
+  }
+}


### PR DESCRIPTION
Fixes #87, and makes accidentally crafting two of the wrong glider wing fine, because you can just "rotate" them.