### PR TITLE
Greatly increase speed of xp shower

### DIFF
--- a/src/main/kotlin/io/github/lucaargolo/kibe/blocks/miscellaneous/XpShowerBlockEntity.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/blocks/miscellaneous/XpShowerBlockEntity.kt
@@ -30,7 +30,7 @@ class XpShowerBlockEntity(xpShower: XpShower, pos: BlockPos, state: BlockState):
 
             val extractable = FluidAttributes.EXTRACTABLE.get(world, pos.add(dir.vector))
 
-            var i = 3 + world.random.nextInt(5) + world.random.nextInt(5)
+            var i = 8 + world.random.nextInt(world.getReceivedRedstonePower(pos) * 5)
 
             while (i > 0) {
                 val j = ExperienceOrbEntity.roundToOrbSize(i)

--- a/src/main/kotlin/io/github/lucaargolo/kibe/blocks/miscellaneous/XpShowerBlockEntity.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/blocks/miscellaneous/XpShowerBlockEntity.kt
@@ -30,7 +30,7 @@ class XpShowerBlockEntity(xpShower: XpShower, pos: BlockPos, state: BlockState):
 
             val extractable = FluidAttributes.EXTRACTABLE.get(world, pos.add(dir.vector))
 
-            var i = 8 + world.random.nextInt(world.getReceivedRedstonePower(pos) * 5)
+            var i = 8 + world.random.nextInt(world.getReceivedRedstonePower(pos) * 3)
 
             while (i > 0) {
                 val j = ExperienceOrbEntity.roundToOrbSize(i)


### PR DESCRIPTION
Increases the base xp drain rate, and allows it to drain even faster with higher redstone power levels, The current drain rate is far too slow. The xp drain rate with power level = 1 is just barely faster than the average drain rate before