### PR TITLE
Move to 1.18.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ dependencies {
     modCompileOnly ("net.oskarstrom:DashLoader:${project["dashloader_version"]}")
 
     //modImplementation("me.shedaniel:RoughlyEnoughItems-fabric:${project["rei_version"]}")
-    modRuntime("com.terraformersmc:modmenu:${project["modmenu_version"]}")
+    modRuntimeOnly("com.terraformersmc:modmenu:${project["modmenu_version"]}")
 }
 
 tasks.processResources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,8 @@ operator fun Project.get(property: String): String {
 }
 
 configure<JavaPluginConvention> {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 version = project["mod_version"]

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@
 org.gradle.jvmargs=-Xmx4G
 
 # Gradle Plugins
-kotlin_version=1.5.0
-loom_version=0.10-SNAPSHOT
+kotlin_version=1.6.10
+loom_version=0.11.30
 grgit_version=4.1.0
 cursegradle_version=1.4.0
 modrinth_version=1.2.1
@@ -14,20 +14,20 @@ mod_version=1.9.4-BETA+1.18
 maven_group=io.github.lucaargolo
 
 # Fabric Properties
-minecraft_version=1.18-pre1
-yarn_mappings=1.18-pre1+build.5
-loader_version=0.12.5
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.22
+loader_version=0.13.3
 
 #Fabric api
-fabric_version=0.42.2+1.18
+fabric_version=0.46.4+1.18
 fabric_kotlin_version=1.6.0+kotlin.1.5.0
 
 # Libraries
-pal_version=1.4.0
-trinkets_version=3.0.4
+pal_version=1.5.0
+trinkets_version=3.2.0
 dashloader_version=2.0
-modmenu_version=3.0.0
-rei_version=6.1.329
+modmenu_version=3.0.1
+rei_version=7.3.432
 
 # Publishing
 curseforge_id=388832

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/github/lucaargolo/kibe/blocks/chunkloader/ChunkLoaderScreen.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/blocks/chunkloader/ChunkLoaderScreen.kt
@@ -56,7 +56,7 @@ class ChunkLoaderScreen(be: ChunkLoaderBlockEntity): Screen(TranslatableText("sc
         identifier = mc.textureManager.registerDynamicTexture("chunk_loader_minimap", texture)
     }
 
-    override fun isPauseScreen() = false
+    override fun shouldPause() = false
 
     private val backgroundHeight = 102
     private val backgroundWidth = 94


### PR DESCRIPTION
Updates versions for fabric, loom, kotlin, libraries, and from Minecraft 1.18-pre1 to 1.18.1. This required the java target to be 1.17 instead of 1.16.

isPauseScreen() was renamed in Minecraft to shouldPause(), so it had to be changed in code too.