### PR TITLE
Ignore VacuumHopperRecipe on Recipe Book

### DIFF
--- a/src/main/kotlin/io/github/lucaargolo/kibe/recipes/vacuum/VacuumHopperRecipe.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/recipes/vacuum/VacuumHopperRecipe.kt
@@ -49,4 +49,6 @@ class VacuumHopperRecipe(private val id: Identifier, val ticks: Int, val xpInput
 
     override fun getIngredients(): DefaultedList<Ingredient> = DefaultedList.ofSize(1, input)
 
+    override fun isIgnoredInRecipeBook(): Boolean = true
+
 }


### PR DESCRIPTION
Currently, Kibe will always produce these 2 console warnings when joining a world:

![image](https://user-images.githubusercontent.com/33578169/193420755-a2e78b96-0c65-488e-b9ab-bdacf6e211d5.png)

This PR sets `isIgnoredInRecipeBook` to `true` on `VacuumHopperRecipe`, fixing this issue.
