### PR TITLE
Custom DamageSource for Spikes as alternative to FakePlayer

### DIFF
--- a/src/main/java/io/github/lucaargolo/kibe/mixin/LivingEntityMixin.java
+++ b/src/main/java/io/github/lucaargolo/kibe/mixin/LivingEntityMixin.java
@@ -5,6 +5,7 @@ import io.github.lucaargolo.kibe.items.ItemCompendiumKt;
 import io.github.lucaargolo.kibe.items.miscellaneous.Glider;
 import io.github.lucaargolo.kibe.items.miscellaneous.SleepingBag;
 import io.github.lucaargolo.kibe.utils.SlimeBounceHandler;
+import io.github.lucaargolo.kibe.utils.SpikeDamageSource;
 import io.github.lucaargolo.kibe.utils.SpikeHelper;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
@@ -30,6 +31,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class LivingEntityMixin extends Entity {
 
     @Shadow public abstract ItemStack getStackInHand(Hand hand);
+    @Shadow protected int playerHitTimer;
 
     public LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
@@ -101,7 +103,12 @@ public abstract class LivingEntityMixin extends Entity {
             }
         }
     }
-
+    @Inject(at = @At("HEAD"), method = "damage", cancellable = true)
+    private void damage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
+        if(source instanceof SpikeDamageSource.DiamondSpikeDamageSource) {
+            this.playerHitTimer = 100;
+        }
+    }
     @SuppressWarnings("ConstantConditions")
     @Inject(at = @At("HEAD"), method = "shouldDropLoot", cancellable = true)
     private void shouldDropLoot(CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/kotlin/io/github/lucaargolo/kibe/blocks/miscellaneous/Spikes.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/blocks/miscellaneous/Spikes.kt
@@ -1,6 +1,6 @@
 package io.github.lucaargolo.kibe.blocks.miscellaneous
 
-import io.github.lucaargolo.kibe.utils.FakePlayerEntity
+import io.github.lucaargolo.kibe.utils.SpikeDamageSource
 import io.github.lucaargolo.kibe.utils.SpikeHelper
 import net.minecraft.block.Block
 import net.minecraft.block.BlockRenderType
@@ -8,7 +8,6 @@ import net.minecraft.block.BlockState
 import net.minecraft.block.ShapeContext
 import net.minecraft.entity.Entity
 import net.minecraft.entity.LivingEntity
-import net.minecraft.entity.damage.DamageSource
 import net.minecraft.item.ItemPlacementContext
 import net.minecraft.state.StateManager
 import net.minecraft.state.property.Properties
@@ -43,8 +42,8 @@ class Spikes(private val type: Type, settings: Settings): Block(settings) {
         if(!world.isClient && entity is LivingEntity) {
             SpikeHelper.setSpike(entity, type)
             when(type) {
-                Type.IRON, Type.STONE -> entity.damage(DamageSource.GENERIC, type.damage)
-                Type.GOLD, Type.DIAMOND -> entity.damage(DamageSource.player(FakePlayerEntity(world)), type.damage)
+                Type.IRON, Type.STONE -> entity.damage(SpikeDamageSource.INSTANCE, type.damage)
+                Type.GOLD, Type.DIAMOND -> entity.damage(SpikeDamageSource.DiamondSpikeDamageSource.INSTANCE, type.damage)
             }
             SpikeHelper.setSpike(entity, null)
         }

--- a/src/main/kotlin/io/github/lucaargolo/kibe/utils/SpikeDamageSource.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/utils/SpikeDamageSource.kt
@@ -1,0 +1,23 @@
+package io.github.lucaargolo.kibe.utils
+
+import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.damage.DamageSource
+import net.minecraft.text.Text
+
+open class SpikeDamageSource(name: String = "Spikes"): DamageSource(name) {
+    companion object {
+        val INSTANCE = SpikeDamageSource()
+    }
+    override fun getDeathMessage(entity: LivingEntity?): Text {
+        return Text.of("${entity?.name ?: "unknown"} got spiked to death.")
+    }
+
+    class DiamondSpikeDamageSource: SpikeDamageSource("Diamond Spikes") {
+        companion object {
+            val INSTANCE = DiamondSpikeDamageSource()
+        }
+        override fun getDeathMessage(entity: LivingEntity?): Text {
+            return Text.of("${entity?.name ?: "unknown"} got fancily spiked to death.")
+        }
+    }
+}


### PR DESCRIPTION
Diamond Spikes' FakePlayer causes the warning "Received unknown attacker" on clients when damaging entities while connected to a dedicated server.

In an attempt to fix this, preserve functionality, and add a proper death message; I've opted to use a custom DamageSource and a mixin that sets the playerHitTimer when the Diamond or Gold spikes damage the entity.