### PR TITLE
fix: Updating lady snake to reachable site

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ repositories {
     }
     maven {
         name = "Ladysnake Mods"
-        url = uri("https://ladysnake.jfrog.io/artifactory/mods")
+        url = url = uri("https://maven.ladysnake.org/releases")
     }
     maven {
         name = "JitPack"


### PR DESCRIPTION
I tried pulling down this new branch and the old [site](https://ladysnake.jfrog.io/artifactory/mods) was throwing 409 codes and seems like the lease was allowed to lapse. I found this new site which seems to work. 