### PR TITLE
Feature: Adds drink XP feature

### DIFF
--- a/src/main/kotlin/io/github/lucaargolo/kibe/utils/FluidUtil.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/utils/FluidUtil.kt
@@ -25,6 +25,8 @@ fun writeTank(tag: NbtCompound, tank: SingleVariantStorage<FluidVariant>): NbtCo
 fun interactPlayerHand(tank: Storage<FluidVariant>, player: PlayerEntity, hand: Hand): ActionResult {
     return if (FluidStorageUtil.interactWithFluidStorage(tank, player, hand)) {
         ActionResult.success(player.world.isClient)
+    } else if (!player.world.isClient && XpUtils.canPlayerDrinkXp(tank, player, hand)) {
+        XpUtils.donateXpAction(player, tank as SingleVariantStorage)
     } else {
         ActionResult.PASS
     }

--- a/src/main/kotlin/io/github/lucaargolo/kibe/utils/ModConfig.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/utils/ModConfig.kt
@@ -26,6 +26,8 @@ class ModConfig {
         var lassoDenyList: ArrayList<String> = arrayListOf()
         //Max rings per player
         var maxRingsPerPlayer: Int = 1
+        //Should interacting with XP tank make player drink the XP
+        var xpTankDrinkOnRightClick: Boolean = true
     }
 
     class ChunkLoaderModule {

--- a/src/main/kotlin/io/github/lucaargolo/kibe/utils/XpUtils.kt
+++ b/src/main/kotlin/io/github/lucaargolo/kibe/utils/XpUtils.kt
@@ -1,0 +1,77 @@
+package io.github.lucaargolo.kibe.utils
+
+import io.github.lucaargolo.kibe.MOD_CONFIG
+import io.github.lucaargolo.kibe.fluids.LIQUID_XP
+import io.github.lucaargolo.kibe.fluids.miscellaneous.LiquidXpFluid
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidConstants
+import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage
+import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleVariantStorage
+import net.fabricmc.fabric.api.transfer.v1.transaction.Transaction
+import net.minecraft.entity.player.PlayerEntity
+import net.minecraft.sound.SoundCategory
+import net.minecraft.sound.SoundEvents
+import net.minecraft.util.ActionResult
+import net.minecraft.util.Hand
+import kotlin.math.min
+
+
+object XpUtils {
+
+    const val MB_PER_XP = FluidConstants.BUCKET / 100
+
+    private fun isTankValidXpDonor(tank: Storage<FluidVariant>) =
+        tank is SingleVariantStorage<FluidVariant> && tank.variant.fluid is LiquidXpFluid
+
+
+    fun expToReachNextLvl(nextLevelExp: Int, progress: Float): Int {
+        return nextLevelExp - (nextLevelExp * progress).toInt()
+    }
+
+    fun convertXpToMilibuckets(xp: Long) = MB_PER_XP * xp
+
+    fun convertMilibucketsToXp(milibuckets: Long) = milibuckets / MB_PER_XP
+
+    fun donateXpAction(player: PlayerEntity, tank: SingleVariantStorage<FluidVariant>): ActionResult {
+        if(tank.amount < MB_PER_XP) return ActionResult.FAIL
+
+        val xpToNextLevel = expToReachNextLvl(player.nextLevelExperience, player.experienceProgress)
+
+        val liquidXpToExtract = min(
+            convertXpToMilibuckets(xpToNextLevel.toLong()),
+            tank.amount
+        )
+
+        Transaction.openOuter().also { transaction ->
+            var extractedAmount = -1L
+            tank.extract(FluidVariant.of(LIQUID_XP), liquidXpToExtract, transaction).let { extractedAmount = it }
+            transaction.addCloseCallback { _, result ->
+                if(result.wasAborted()) {
+                    return@addCloseCallback
+                }
+                player.addExperience(convertMilibucketsToXp(liquidXpToExtract).toInt())
+                if(extractedAmount > 0) {
+                    player.world.playSound(
+                        null,
+                        player.blockPos,
+                        SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP,
+                        SoundCategory.AMBIENT,
+                        .5f,
+                        player.world.random.nextBetween(3,9).toFloat() / 10)
+                }
+            }
+           transaction.commit()
+        }
+
+        return ActionResult.success(true)
+    }
+
+    fun canPlayerDrinkXp(tank: Storage<FluidVariant>, player: PlayerEntity, hand: Hand): Boolean {
+        return MOD_CONFIG.miscellaneousModule.xpTankDrinkOnRightClick &&
+                player.mainHandStack.isEmpty &&
+                hand == Hand.MAIN_HAND &&
+                isTankValidXpDonor(tank)
+
+    }
+
+}


### PR DESCRIPTION
Likewise it was in OpenBlocks the player could be able to consume the Liquid XP from the tanks by right-clicking into it.

This feature would help player to easily achieve the desired level for enchanting and other applications.

- Works in Regular tanks and ender tanks
- Works only on right clicking with empty main hand
- Uses transactions to validate if liquidXP was successfully extracted from tank
- Can disable this feature on Config